### PR TITLE
Allows configuration of the card destination after being played

### DIFF
--- a/src/ducks/actionCreators.js
+++ b/src/ducks/actionCreators.js
@@ -35,6 +35,7 @@ export const createCard = ({
   cost,
   actions,
   needsTarget,
+  destination,
   target,
   image
 }) => ({
@@ -46,6 +47,7 @@ export const createCard = ({
     cost,
     actions,
     needsTarget,
+    destination,
     target,
     image
   }

--- a/src/ducks/middlewares.js
+++ b/src/ducks/middlewares.js
@@ -194,7 +194,7 @@ export const playCardExecute = store => next => action => {
       store.dispatch(
         actions.moveCardByUUID({
           uuidArray: [cardUuid],
-          targetDeck: 'discard'
+          targetDeck: card.destination
         })
       );
 

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -417,6 +417,7 @@ export default function reducer(state = initialState, action = {}) {
         cost,
         actions,
         needsTarget,
+        destination,
         image
       } = action.payload;
       return {
@@ -431,6 +432,7 @@ export default function reducer(state = initialState, action = {}) {
               description,
               actions,
               needsTarget,
+              destination: destination ? destination : 'discard',
               image
             }
           }


### PR DESCRIPTION
Defaults to 'discard', can be tested by adding a 'destination' property
to any card in the library

Notes:

- if a card has a destination of 'hand' it will be kept in the hand
for the duration of the current turn, thus having unlimited uses, but it
will still be moved to the discard pile when the turn ends

- if a card has a destination of 'deck' it will be moved back to the
deck and won't be moved to the 'discard' pile at the end of the turn